### PR TITLE
fix FindLib makefile to make it buildable standalone

### DIFF
--- a/FindLib/etc/makefile
+++ b/FindLib/etc/makefile
@@ -1,6 +1,7 @@
 ### makefile for findlib
 
-OBJ_DIR := obj
+SYS_VERS  := r$(shell uname -r)
+OBJ_DIR := obj.$(SYS_VERS)
 DEP_DIR := depends
 
 
@@ -9,13 +10,27 @@ DEP_DIR := depends
 OPTIMIZER		=	-O0
 
 CC		     	=	gcc
-CFLAGS			=	$(OPTIMIZER) -Wall -Wno-multichar -Wno-ctor-dtor-privacy
+
+# This is needed to be able to compile on either nightlies, or beta4.
+# See https://dev.haiku-os.org/ticket/11818 (fixed for good in hrev57497).
+# We can simplify this once the haikuports buildmasters switch to beta5.
+
+HAIKU_HREV_NUM = $(shell uname -v | cut -d " " -f 1 | cut -d "+" -f 1 | sed s/hrev//)
+HAS_FIXED_FEATURES_H = $(shell if [ $(strip $(HAIKU_HREV_NUM)) -ge 57497 ]; then echo "YES"; else echo "NO"; fi)
+
+ifeq ($(strip $(HAS_FIXED_FEATURES_H)), YES)
+	CFLAGS	=	$(OPTIMIZER) -Wall -Wno-multichar -Wno-ctor-dtor-privacy -D_DEFAULT_SOURCE -DSTDC_HEADERS
+else
+	CFLAGS	=	$(OPTIMIZER) -Wall -Wno-multichar -Wno-ctor-dtor-privacy -D__USE_GNU -DSTDC_HEADERS
+endif
 
 LD				=	gcc
 LDFLAGS			=	
-SHAREDLIB_FLAGS	=	-nostart -Xlinker -soname=$(notdir $@)
+SHAREDLIB_FLAGS	=	-shared -Xlinker -soname=$(notdir $@)
 
 
+MAKE_DEPEND		 = ../../etc/MakeDepend.sh $(CFLAGS) -c $< -dep $@
+MAKE_CC			 = $(CC) $(CFLAGS) -c $< -o $@
 
 
 FINDLIB_DIR := ..

--- a/FindLib/etc/makefile
+++ b/FindLib/etc/makefile
@@ -7,7 +7,7 @@ DEP_DIR := depends
 
 
 
-OPTIMIZER		=	-O0
+OPTIMIZER		=	-O3
 
 CC		     	=	gcc
 
@@ -19,7 +19,7 @@ HAIKU_HREV_NUM = $(shell uname -v | cut -d " " -f 1 | cut -d "+" -f 1 | sed s/hr
 HAS_FIXED_FEATURES_H = $(shell if [ $(strip $(HAIKU_HREV_NUM)) -ge 57497 ]; then echo "YES"; else echo "NO"; fi)
 
 ifeq ($(strip $(HAS_FIXED_FEATURES_H)), YES)
-	CFLAGS	=	$(OPTIMIZER) -Wall -Wno-multichar -Wno-ctor-dtor-privacy -D_DEFAULT_SOURCE -DSTDC_HEADERS
+	CFLAGS	=	$(OPTIMIZER) -Wall -Wno-multichar -Wno-ctor-dtor-privacy
 else
 	CFLAGS	=	$(OPTIMIZER) -Wall -Wno-multichar -Wno-ctor-dtor-privacy -D__USE_GNU -DSTDC_HEADERS
 endif


### PR DESCRIPTION
Copy the "features" CFLAGS portion and some missing defines from the main makefile to fix the standalone build of FindLib.

Change the definition of OBJ_DIR to match the main makefile.

FindLib may be useful as a standalone library which could be packaged separately and TraX made dependendent on it.